### PR TITLE
Allow running different analysis' without need to change hardcoded lines

### DIFF
--- a/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/DataflowAnalysisJob.java
+++ b/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/DataflowAnalysisJob.java
@@ -18,13 +18,15 @@ public class DataflowAnalysisJob extends AbstractBlackboardInteractingJob<KeyVal
 
 	private final URI allocationURI;
 	private final URI usageURI;
+	private final RunCustomJavaBasedAnalysisJob runAnalysisJob;
 	protected static final String PCM_MODEL_PARTITION = "pcmModels";
 	private static final String ALL_CHARACTERISTICS_RESULT_KEY = "resultAllCharacteristicsKey";
 	private static final String VIOLATIONS_RESULT_KEY = "resultViolationsKey";
 
-	public DataflowAnalysisJob(URI allocationURI, URI usageURI) {
+	public DataflowAnalysisJob(URI allocationURI, URI usageURI, RunCustomJavaBasedAnalysisJob runAnalysisJob) {
 		this.usageURI = usageURI;
 		this.allocationURI = allocationURI;
+		this.runAnalysisJob = runAnalysisJob;
 	}
 
 	@Override
@@ -39,7 +41,7 @@ public class DataflowAnalysisJob extends AbstractBlackboardInteractingJob<KeyVal
 				Arrays.asList(usageModelLocation, allocationLocation));
 		job.add(loadUsageModelJob);
 
-		var runAnalysisJob = new RunCustomJavaBasedAnalysisJob(usageModelLocation, allocationLocation,
+		runAnalysisJob.prepareJob(usageModelLocation, allocationLocation,
 				ALL_CHARACTERISTICS_RESULT_KEY, VIOLATIONS_RESULT_KEY);
 		job.add(runAnalysisJob);
 		

--- a/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/DataflowAnalysisWorkflow.java
+++ b/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/DataflowAnalysisWorkflow.java
@@ -20,7 +20,7 @@ import tools.mdsd.library.standalone.initialization.log4j.Log4jInitilizationTask
 
 public class DataflowAnalysisWorkflow extends SequentialBlackboardInteractingJob<KeyValueMDSDBlackboard> {
 
-	public DataflowAnalysisWorkflow(URI allocationURI, URI usageURI) {
+	public DataflowAnalysisWorkflow(URI allocationURI, URI usageURI, RunCustomJavaBasedAnalysisJob runAnalysisJob) {
 
 		// TODO: Stephans Test Initilaizer der Palladio Erweiterung anschauen
 		//IProfileRegistry.eINSTANCE.getClass();
@@ -47,7 +47,7 @@ public class DataflowAnalysisWorkflow extends SequentialBlackboardInteractingJob
 		Logger.getLogger(AbstractCleaningLinker.class).setLevel(Level.WARN);
 
 		// build and run job
-		this.add(new DataflowAnalysisJob(allocationURI, usageURI));
+		this.add(new DataflowAnalysisJob(allocationURI, usageURI, runAnalysisJob));
 	}
 
 }

--- a/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/RunOnlineShopAnalysisJob.java
+++ b/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/RunOnlineShopAnalysisJob.java
@@ -1,0 +1,80 @@
+package edu.kit.kastel.dsis.fluidtrust.dataflow.analysis;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.palladiosimulator.dataflow.confidentiality.pcm.model.confidentiality.dictionary.PCMDataDictionary;
+import org.palladiosimulator.pcm.core.entity.Entity;
+
+import de.uka.ipd.sdq.workflow.jobs.JobFailedException;
+import edu.kit.kastel.dsis.fluidtrust.casestudy.pcs.analysis.dto.ActionBasedQueryResult;
+import edu.kit.kastel.dsis.fluidtrust.casestudy.pcs.analysis.dto.CharacteristicValue;
+
+public class RunOnlineShopAnalysisJob extends RunCustomJavaBasedAnalysisJob {
+
+	@Override
+	protected ActionBasedQueryResult findViolations(List<PCMDataDictionary> dataDictionaries,
+			ActionBasedQueryResult allCharacteristics) throws JobFailedException {
+		var enumCharacteristicTypes = getAllEnumCharacteristicTypes(dataDictionaries);
+		System.out.println("\n\nCHARACTERISTIC TYPES --------------------");
+		enumCharacteristicTypes.forEach(entry -> System.out.println(entry.getName()));
+
+		var ctServerLocation = findByName(enumCharacteristicTypes, "ServerLocation");
+		var ctDataSensitivity = findByName(enumCharacteristicTypes, "DataSensitivity");
+
+		var violations = new ActionBasedQueryResult();
+
+		System.out.println("\n\nELEMENTS AND CHARACTERISTICS --------------------");
+
+		for (var resultEntry : allCharacteristics.getResults().entrySet()) {
+			for (var queryResult : resultEntry.getValue()) {
+
+				var serverLocations = queryResult.getNodeCharacteristics().stream()
+						.filter(cv -> cv.getCharacteristicType() == ctServerLocation)
+						.map(CharacteristicValue::getCharacteristicLiteral).map(it -> it.getName())
+						.collect(Collectors.toList());
+
+				var dataSensitivites = queryResult.getDataCharacteristics().values().stream()
+						.flatMap(Collection::stream).filter(cv -> cv.getCharacteristicType() == ctDataSensitivity)
+						.map(CharacteristicValue::getCharacteristicLiteral).map(it -> it.getName())
+						.collect(Collectors.toList());
+
+				var element = getElementRepresentation(queryResult.getElement());
+
+				System.out.println(element + ", " + serverLocations.toString() + ", " + dataSensitivites.toString());
+
+				// Actual constraint
+				if (serverLocations.contains("nonEU") && dataSensitivites.contains("Personal")) {
+					violations.addResult(resultEntry.getKey(), queryResult);
+				}
+			}
+		}
+
+		System.out.println("\n\nVIOLATIONS --------------------");
+		violations.getResults().forEach((sequence, resultDTO) -> {
+			resultDTO.forEach(it -> System.out.println(getElementRepresentation(it.getElement())));
+
+			System.out.println("-- with sequence --");
+
+			// Find path from newest entry level system call (might not be enough though)
+			var pruneSequence = sequence.stream().takeWhile(
+					it -> !resultDTO.stream().map(e -> e.getElement()).collect(Collectors.toList()).contains(it))
+					.collect(Collectors.toList());
+
+			var sysCalls = pruneSequence.stream()
+					.filter(e -> ((Entity) e.getElement()).eClass().getName().equals("EntryLevelSystemCall"))
+					.collect(Collectors.toList());
+			var lastEntryLevelSystemCall = sysCalls.stream().skip(sysCalls.stream().count() - 1).findFirst().get();
+
+			var finalSequence = pruneSequence.stream().dropWhile(it -> !it.equals(lastEntryLevelSystemCall));
+
+			finalSequence.forEach(it -> System.out.println(getElementRepresentation(it)));
+
+			System.out.println("\n\n");
+		});
+
+		return violations;
+	}
+
+}

--- a/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/RunTravelPlannerAnalysisJob.java
+++ b/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/RunTravelPlannerAnalysisJob.java
@@ -1,0 +1,84 @@
+package edu.kit.kastel.dsis.fluidtrust.dataflow.analysis;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.palladiosimulator.dataflow.confidentiality.pcm.model.confidentiality.dictionary.PCMDataDictionary;
+import org.palladiosimulator.pcm.core.entity.Entity;
+
+import de.uka.ipd.sdq.workflow.jobs.JobFailedException;
+import edu.kit.kastel.dsis.fluidtrust.casestudy.pcs.analysis.dto.ActionBasedQueryResult;
+import edu.kit.kastel.dsis.fluidtrust.casestudy.pcs.analysis.dto.CharacteristicValue;
+
+public class RunTravelPlannerAnalysisJob extends RunCustomJavaBasedAnalysisJob {
+
+	@Override
+	protected ActionBasedQueryResult findViolations(List<PCMDataDictionary> dataDictionaries,
+			ActionBasedQueryResult allCharacteristics) throws JobFailedException {
+		var enumCharacteristicTypes = getAllEnumCharacteristicTypes(dataDictionaries);
+		System.out.println("\n\nCHARACTERISTIC TYPES --------------------");
+		enumCharacteristicTypes.forEach(entry -> System.out.println(entry.getName()));
+
+		var ctGrantedRoles = findByName(enumCharacteristicTypes, "GrantedRoles");
+		var ctAssignedRoles = findByName(enumCharacteristicTypes, "AssignedRoles");
+
+		var violations = new ActionBasedQueryResult();
+
+		System.out.println("\n\nELEMENTS AND CHARACTERISTICS --------------------");
+
+		for (var resultEntry : allCharacteristics.getResults().entrySet()) {
+			for (var queryResult : resultEntry.getValue()) {
+
+				var availableVariables = queryResult.getDataCharacteristics().keySet();
+
+				for (String variable : availableVariables) {
+					var grantedRoles = queryResult.getDataCharacteristics().get(variable).stream()
+							.filter(cv -> cv.getCharacteristicType() == ctGrantedRoles)
+							.map(CharacteristicValue::getCharacteristicLiteral).map(it -> it.getName())
+							.collect(Collectors.toList());
+
+					var assignedRoles = queryResult.getNodeCharacteristics().stream()
+							.filter(cv -> cv.getCharacteristicType() == ctAssignedRoles)
+							.map(val -> val.getCharacteristicLiteral()).map(it -> it.getName())
+							.collect(Collectors.toList());
+
+					var element = getElementRepresentation(queryResult.getElement());
+
+					System.out.println(element + ", " + variable + ", " + grantedRoles.toString() + ", "
+							+ assignedRoles.toString());
+
+					// Actual constraint
+					if(!grantedRoles.stream().anyMatch(it -> assignedRoles.contains(it))) {
+						violations.addResult(resultEntry.getKey(), queryResult);
+					}
+				}
+			}
+		}
+
+		System.out.println("\n\nVIOLATIONS --------------------");
+		violations.getResults().forEach((sequence, resultDTO) -> {
+			resultDTO.forEach(it -> System.out.println(getElementRepresentation(it.getElement())));
+
+			System.out.println("-- with sequence --");
+
+			// Find path from newest entry level system call (might not be enough though)
+			var pruneSequence = sequence.stream().takeWhile(
+					it -> !resultDTO.stream().map(e -> e.getElement()).collect(Collectors.toList()).contains(it))
+					.collect(Collectors.toList());
+
+			var sysCalls = pruneSequence.stream()
+					.filter(e -> ((Entity) e.getElement()).eClass().getName().equals("EntryLevelSystemCall"))
+					.collect(Collectors.toList());
+			var lastEntryLevelSystemCall = sysCalls.stream().skip(sysCalls.stream().count() - 1).findFirst().get();
+
+			var finalSequence = pruneSequence.stream().dropWhile(it -> !it.equals(lastEntryLevelSystemCall));
+
+			finalSequence.forEach(it -> System.out.println(getElementRepresentation(it)));
+
+			System.out.println("\n\n");
+		});
+
+		return violations;
+	}
+
+}

--- a/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/tests/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/ConfidentialityAnalysisTest.java
+++ b/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/tests/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/ConfidentialityAnalysisTest.java
@@ -25,31 +25,34 @@ public class ConfidentialityAnalysisTest extends TestBase {
 	
 	@Test
 	public void testOnlineShop() throws JobFailedException, UserCanceledException {
-		System.out.println("Hello World!");
+		System.out.println("\n------------------------------------------------------------------------------------");
+		System.out.println("Running Online Shop Analysis:\n");
 		
 		final var allocationURI = TestInitializer.getModelURI("models/InternationalOnlineShop/default.allocation");
 		final var usageURI = TestInitializer.getModelURI("models/InternationalOnlineShop/default.usagemodel");
-		final var workflow = new DataflowAnalysisWorkflow(allocationURI, usageURI);
+		final var workflow = new DataflowAnalysisWorkflow(allocationURI, usageURI, new RunOnlineShopAnalysisJob());
 		workflow.execute(new NullProgressMonitor());
 	}
 	
 	@Test
 	public void testBranchingOnlineShop() throws JobFailedException, UserCanceledException {
-		System.out.println("Hello World!");
+		System.out.println("\n------------------------------------------------------------------------------------");
+		System.out.println("Running Branching Online Shop Analysis:\n");
 		
 		final var allocationURI = TestInitializer.getModelURI("models/BranchingOnlineShop/default.allocation");
 		final var usageURI = TestInitializer.getModelURI("models/BranchingOnlineShop/default.usagemodel");
-		final var workflow = new DataflowAnalysisWorkflow(allocationURI, usageURI);
+		final var workflow = new DataflowAnalysisWorkflow(allocationURI, usageURI, new RunOnlineShopAnalysisJob());
 		workflow.execute(new NullProgressMonitor());
 	}
 	
 	@Test
 	public void testTravelPlanner() throws JobFailedException, UserCanceledException {
-		System.out.println("Hello Travel Planner!");
+		System.out.println("\n------------------------------------------------------------------------------------");
+		System.out.println("Running Travel Planner Analysis:\n");
 		
 		final var allocationURI = TestInitializer.getModelURI("models/TravelPlanner/travelPlanner.allocation");
 		final var usageURI = TestInitializer.getModelURI("models/TravelPlanner/travelPlanner.usagemodel");
-		final var workflow = new DataflowAnalysisWorkflow(allocationURI, usageURI);
+		final var workflow = new DataflowAnalysisWorkflow(allocationURI, usageURI, new RunTravelPlannerAnalysisJob());
 		workflow.execute(new NullProgressMonitor());
 	}
 


### PR DESCRIPTION
Just used a bit of abstraction and moved code from `findViolationsOnlineShop()` and `findViolationsTravelPlanner()` to separate classes as it annoyed me that code must always be changed to test a specific model.

Now the unit test will run the analysis for all 3 currently available models.

_It's not the finest or most structured piece of code but it works better than before and I guess thats enough as it will be replaced anyway._